### PR TITLE
Update README file for proper plugin install for elasticsearch version 0.90.2 and above

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -17,7 +17,7 @@ h2. Installation
 
 In order to install the plugin, simply run the following command in the elasticsearch home directory: 
 
-h3. Version 0.90 -> 0.90.1 (including) (see 0.90.2 Release Notes and issue <a href="https://github.com/elasticsearch/elasticsearch/issues/3112">#3112</a>)
+h3. Version 0.90 -> 0.90.1 (including) (see <a href="http://www.elasticsearch.org/downloads/">0.90.2 Release Notes</a> and issue <a href="https://github.com/elasticsearch/elasticsearch/issues/3112">#3112</a>)
 <pre>
 bin/plugin -url http://dl.bintray.com/content/imotov/elasticsearch-plugins/elasticsearch-analysis-morphology-VERSION.zip -install analysis-morphology
 </pre>
@@ -37,7 +37,7 @@ bin/plugin --install analysis-morphology --url http://dl.bintray.com/content/imo
 where @VERSION@ is the version of the plugin from the compatibility table. For examples to install version @1.1.0@ run 
 
 <pre>
-bin/plugin -install analysis-morphology i-url http://dl.bintray.com/content/imotov/elasticsearch-plugins/elasticsearch-analysis-morphology-1.1.0.zip 
+bin/plugin --install analysis-morphology --url http://dl.bintray.com/content/imotov/elasticsearch-plugins/elasticsearch-analysis-morphology-1.1.0.zip 
 </pre>
 
 


### PR DESCRIPTION
Because, plugin manager was update in version 0.90.2 the old installation command is not valid anymore, the new command should use --install and --url instead, and order, for some reason, is important, i.e. --install should come first, before --url.
